### PR TITLE
Small fixes for various tracebacks

### DIFF
--- a/intuos4oled.py
+++ b/intuos4oled.py
@@ -102,13 +102,13 @@ class Screen:
             filename = self.datafile
         print ("Saving to %s"%filename)
         with open(filename, 'wb') as outfile:
-            outfile.write("(%u,%u)\n"%(self.ids[0], self.ids[1]))
+            outfile.write(("(%u,%u)\n" % (self.ids[0], self.ids[1])).encode())
             for led in range(4):
                 for button in range(8):
                     if self.raw[led][button] is None:
-                        outfile.write("None\n")
+                        outfile.write("None\n".encode())
                     else:
-                        outfile.write("Raw:\n")
+                        outfile.write("Raw:\n".encode())
                         outfile.write(self.raw[led][button])
 
     def load(self, filename = None):
@@ -164,8 +164,8 @@ def sudo_init (ids):
 def set_luminance (path, luminance):
     lumi_path = os.path.join(path, LUMINANCE)
     with open(lumi_path, 'wb') as outfile:
-        outfile.write(str(luminance))
-    
+        outfile.write(str(luminance).encode())
+
 def img_to_raw (im, flip, rv, keep_ratio = False):
     """Convert an image to a raw 1024 bytearray for the Intuos4.
 

--- a/intuos4oled.py
+++ b/intuos4oled.py
@@ -231,10 +231,10 @@ def img_to_raw (im, flip, rv, keep_ratio = False):
         
     # Convert grayscale image into interlaced 4bits raw bytes.
     (w, h) = (TARGET_WIDTH, TARGET_HEIGHT)
-    raw = bytearray(w*h/2)
+    raw = bytearray(int(w * h / 2))
     pos = 0
 
-    for j in range(h/2):
+    for j in range(int(h / 2)):
         (y, n1, n2) = (h - 2*j, -1, -2) if flip else (2*j, 0, 1)
         
         for i in range(w):
@@ -357,7 +357,7 @@ def clear_buttons (button, span, screen, flip):
     last_button = (button if span is None else
                        (button - span + 1 if flip else button + span - 1))
     r = range(min(button, last_button), max(button, last_button)+1)
-    raw = bytearray(TARGET_HEIGHT*TARGET_WIDTH/2)
+    raw = bytearray(int(TARGET_HEIGHT * TARGET_WIDTH / 2))
     for b in r:
         print ("Clearing button %u"%b)
         update_raw (raw, b, screen)


### PR DESCRIPTION
Hi, I tried making my small Intuos 4 (PTK-440 model) work* with this, and in the process I encountered a bunch of tracebacks that this branch here ("small_fixes") fixes on my end. In _theory_ these changes should be correct, but I have no way to tell because I realized _afterwards_, when the code gave me no more errors, that the PTK-440 model doesn't actually have programmable OLEDs! 🤦 ridiculous, huh? But at least you get my theoretical fixes for the rest. Hoping it's useful somehow.

See if they work on your end?

(There are some very minor changes to spacing between operators as per Python's `PEP-8`, but I otherwise tried to be non-invasive in the code because I have no way to test if there are side-effects, since my hardware doesn't have OLEDs… but at least there are no more tracebacks, and the tablet didn't catch on fire.)

*: https://github.com/nekohayo/intuos4-oled/tree/intuos4-small was how I initially allowed the script to recognize my "small" Intuos 4, but even with the "small_fixes" branch combined with this commit, it doesn't light up anything on the tablet in practice. So I've separated out that commit to a separate branch, which I suppose won't be used for anything but who knows.